### PR TITLE
[pubsub] New format for go-ipfs >= 0.11.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master, devel, ci ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, aleph/master ]
 
 jobs:
   build:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiohttp>=3.7.4
 aiofiles>=0.4.0
 base58>=1.0.2
 orjson>=3,<3.4
+py-multibase>=1.0.0,<2.0.0


### PR DESCRIPTION
Modified the format used to subscribe and publish on pubsub topics.
go-ipfs v0.11.0 introduces a new format requiring multibase
base64url encoding for most parameters.
Additionally, published data must now be added as a multipart form
instead of a URL parameter.