### PR TITLE
Support Kubo v0.14.0

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9"]
+#        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10]
+        python-version: ["3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,7 +2,6 @@ name: aioipfs-build
 
 on:
   push:
-    branches: [ master, devel, ci ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,7 @@ jobs:
     - name: extract
       run: |
         tar -C $GITHUB_WORKSPACE -xzvf kubo_linux-amd64.tar.gz
-        echo "${GITHUB_WORKSPACE}/go-ipfs" >> $GITHUB_PATH
+        echo "${GITHUB_WORKSPACE}/kubo" >> $GITHUB_PATH
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,11 +31,11 @@ jobs:
     - name: wget
       uses: wei/wget@v1
       with:
-        args: -O go-ipfs_v0.7.0_linux-amd64.tar.gz https://dist.ipfs.io/go-ipfs/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz
+        args: -O kubo_linux-amd64.tar.gz https://dist.ipfs.tech/kubo/v0.14.0/kubo_v0.14.0_linux-amd64.tar.gz
 
     - name: extract
       run: |
-        tar -C $GITHUB_WORKSPACE -xzvf go-ipfs_v0.7.0_linux-amd64.tar.gz
+        tar -C $GITHUB_WORKSPACE -xzvf kubo_linux-amd64.tar.gz
         echo "${GITHUB_WORKSPACE}/go-ipfs" >> $GITHUB_PATH
 
     - name: Test with pytest
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.9
 
     - name: Build wheel
       run: |

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ import aioipfs
 
 
 def ipfs_getconfig_var(var):
-    sp_getconfig = subprocess.Popen(['kubo', 'config',
+    sp_getconfig = subprocess.Popen(['ipfs', 'config',
                                      var], stdout=subprocess.PIPE)
     stdout, stderr = sp_getconfig.communicate()
     return stdout.decode()
@@ -112,7 +112,7 @@ def ipfsdaemon():
     ipfs_config_json('Experimental.FilestoreEnabled', 'true')
 
     # Run the daemon and wait a bit
-    sp = subprocess.Popen(['kubo', 'daemon'],
+    sp = subprocess.Popen(['ipfs', 'daemon'],
                           stdout=subprocess.PIPE)
     time.sleep(1)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -14,7 +14,7 @@ import aioipfs
 
 
 def ipfs_getconfig_var(var):
-    sp_getconfig = subprocess.Popen(['ipfs', 'config',
+    sp_getconfig = subprocess.Popen(['kubo', 'config',
                                      var], stdout=subprocess.PIPE)
     stdout, stderr = sp_getconfig.communicate()
     return stdout.decode()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -112,7 +112,7 @@ def ipfsdaemon():
     ipfs_config_json('Experimental.FilestoreEnabled', 'true')
 
     # Run the daemon and wait a bit
-    sp = subprocess.Popen(['ipfs', 'daemon'],
+    sp = subprocess.Popen(['kubo', 'daemon'],
                           stdout=subprocess.PIPE)
     time.sleep(1)
 


### PR DESCRIPTION
go-ipfs has been renamed `Kubo`.

The goal of this branch is to support the latest version, [v0.14.0](https://github.com/ipfs/kubo/releases/tag/v0.14.0).

Tests now pass, but the HTTP RPC wire format for experimental commands at `/api/v0/pubsub` changed in https://github.com/ipfs/kubo/releases/tag/v0.11.0 and it is not tested in the pubsub unit tests, that currently only consist in:

https://github.com/aleph-im/aioipfs/blob/f7f968915593517890679c8d1c40313cf91d0e0f/tests/test_client.py#L354-L360

## Changes required

> If you use /api/v0/pubsub/* directly or maintain your own client library, you must adjust your HTTP client code. Byte fields and URL args are now encoded in base64url [Multibase](https://docs.ipfs.io/concepts/glossary/#multibase). Encode/decode bytes using the ipfs multibase --help commands, or use the multiformats libraries ([js-multiformats](https://github.com/multiformats/js-multiformats#readme), [go-multibase](https://github.com/multiformats/go-multibase)).

Low level changes:

- [ ]     topic passed as URL arg in requests to /api/v0/pubsub/* must be encoded in URL-safe multibase (base64url)
- [ ]     data, from, seqno and topicIDs returned in JSON responses are now encoded in multibase
- [ ]     Peer IDs returned in from now use the same default text representation from go-libp2p and peerid encoder/decoder from libp2p. This means the same text representation as in as in swarm peers, which makes it possible to compare them without decoding multibase.
- [ ]     /api/v0/pubsub/pub no longer accepts data to be passed as URL, it has to be sent as multipart/form-data. This removes size limitations based on URL length, and enables regular HTTP clients to publish data to PubSub topics. For example, to publish some-file to topic named test-topic using vanilla curl, one would execute: curl -X POST -v -F "stdin=@some-file" 'http://127.0.0.1:5001/api/v0/pubsub/pub?arg=$(echo -n test-topic | ipfs multibase encode -b base64url)'
- [ ]     ipfs pubsub pub on the command line no longer accepts variadic data arguments. Instead, it expects a single file input or stream of bytes from stdin. This ensures arbitrary stream of bytes can be published, removing limitation around messages that include \n or \r\n.